### PR TITLE
Add config parameter for each frame in encodeAnimation, allow user to set quality to control the webp size

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Frame bitmap.
 
 Duration of frame.
 
+- WebPAnimationFrame.config: `WebPConfig` (optional)
+
+Per-frame encoding configuration. If not provided, default config is used (lossless: 0, quality: 100).
+
 ##### Example
 
 ```javascript
@@ -137,6 +141,12 @@ Duration of frame.
 frames.push({
   data: ctx.getImageData(0, 0, 100, 100).data,
   duration: 20
+})
+// with per-frame config
+frames.push({
+  data: ctx.getImageData(0, 0, 100, 100).data,
+  duration: 20,
+  config: { lossless: 0, quality: 80 }
 })
 const webpData = await encodeAnimation(100, 100, true, frames)
 ...

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,7 @@ export interface WebPConfig {
 export interface WebPAnimationFrame {
 	data: Uint8Array
 	duration: number
+	config?: WebPConfig
 }
 
 export interface DecodedWebPAnimationFrame extends WebPAnimationFrame {

--- a/tests/encode.test.js
+++ b/tests/encode.test.js
@@ -98,8 +98,8 @@ describe('encode', () => {
       ctx.closePath()
       ctx.fill()
       frames.push({
-        data: ctx.getImageData(0, 0, 100, 100).data,
-        duration: 1000
+        data: ctx.getImageData(0, 0, 100, 100).data.buffer,
+        duration: 1000,
       })
     }
     const webpData = await encodeAnimation(100, 100, true, frames)

--- a/webp/encode.cpp
+++ b/webp/encode.cpp
@@ -5,6 +5,12 @@
 using namespace emscripten;
 thread_local val Uint8Array = val::global("Uint8Array");
 
+void applyPicConfig(WebPConfig& webp_config, const SimpleWebPConfig& config)
+{
+	webp_config.quality = config.quality;
+	webp_config.lossless = config.lossless;
+}
+
 val encoder_version()
 {
 	return get_version(WebPGetEncoderVersion());
@@ -26,9 +32,7 @@ val encode(std::string data, int width, int height, bool has_alpha, SimpleWebPCo
 {
 	WebPConfig webp_config;
 	WebPConfigInit(&webp_config);
-
-	webp_config.quality = config.quality;
-	webp_config.lossless = config.lossless;
+	applyPicConfig(webp_config, config);
 
 	WebPMemoryWriter wrt;
 	WebPMemoryWriterInit(&wrt);
@@ -76,8 +80,7 @@ val encodeAnimation(int width, int height, bool has_alpha, std::vector<WebPAnima
 		WebPConfigInit(&config);
 		if (frame.has_config)
 		{
-			config.quality = frame.config.quality;
-			config.lossless = frame.config.lossless;
+			applyPicConfig(config, frame.config);
 		}
 
 		WebPPicture pic;

--- a/webp/encode.cpp
+++ b/webp/encode.cpp
@@ -63,36 +63,37 @@ val encode(std::string data, int width, int height, bool has_alpha, SimpleWebPCo
 	return encoded_data;
 }
 
-val encodeAnimation(int width, int height, bool has_alpha, val durations, std::string data)
+val encodeAnimation(int width, int height, bool has_alpha, std::vector<WebPAnimationFrame> frames)
 {
 	WebPAnimEncoderOptions enc_options;
 	WebPAnimEncoderOptionsInit(&enc_options);
 	WebPAnimEncoder* enc = WebPAnimEncoderNew(width, height, &enc_options);
-	auto frame_durations = vecFromJSArray<int>(durations);
-	int frames = frame_durations.size();
-	int frame_data_size = (has_alpha ? 4 : 3) * width * height;
 	int stride = (has_alpha ? 4 : 3) * width;
-  int timestamp = 0;
-	for (int i = 0; i < frames; i++)
+	int timestamp = 0;
+	for (const auto& frame : frames)
 	{
 		WebPConfig config;
 		WebPConfigInit(&config);
+		if (frame.has_config)
+		{
+			config.quality = frame.config.quality;
+			config.lossless = frame.config.lossless;
+		}
+
 		WebPPicture pic;
 		if (!WebPPictureInit(&pic))
 		{
 			WebPPictureFree(&pic);
 			return val::null();
 		}
-		auto pos = i * frame_data_size;
-		auto pic_data = data.substr(pos, frame_data_size);
 		pic.use_argb = 1;
 		pic.width = width;
 		pic.height = height;
 		has_alpha
-			? WebPPictureImportRGBA(&pic, (uint8_t*)pic_data.c_str(), stride)
-			: WebPPictureImportRGB(&pic, (uint8_t*)pic_data.c_str(), stride);
+			? WebPPictureImportRGBA(&pic, (uint8_t*)frame.data.c_str(), stride)
+			: WebPPictureImportRGB(&pic, (uint8_t*)frame.data.c_str(), stride);
 		int success = WebPAnimEncoderAdd(enc, &pic, timestamp, &config);
-    timestamp = timestamp + frame_durations[i];
+		timestamp = timestamp + frame.duration;
 		if (!success) {
 			return val::null();
 		}

--- a/webp/encode.h
+++ b/webp/encode.h
@@ -1,3 +1,4 @@
+#include <vector>
 #include "src/webp/encode.h"
 #include "src/webp/mux.h"
 #include "emscripten/emscripten.h"
@@ -6,7 +7,15 @@
 struct SimpleWebPConfig
 {
 	int lossless;
-  float quality;   
+  float quality;
+};
+
+struct WebPAnimationFrame
+{
+	int duration;
+	std::string data;
+	SimpleWebPConfig config;
+	bool has_config;
 };
 
 emscripten::val encoder_version();
@@ -17,4 +26,4 @@ emscripten::val encodeRGBA(std::string rgba, int width, int height, int quality_
 
 emscripten::val encode(std::string data, int width, int height, bool use_alpha, SimpleWebPConfig config);
 
-emscripten::val encodeAnimation(int width, int height, bool has_alpha, emscripten::val durations, std::string data);
+emscripten::val encodeAnimation(int width, int height, bool has_alpha, std::vector<WebPAnimationFrame> frames);

--- a/webp/webp.cpp
+++ b/webp/webp.cpp
@@ -10,6 +10,14 @@ EMSCRIPTEN_BINDINGS(module)
 		.field("lossless", &SimpleWebPConfig::lossless)
 		.field("quality", &SimpleWebPConfig::quality);
 
+	emscripten::value_object<WebPAnimationFrame>("WebPAnimationFrame")
+		.field("duration", &WebPAnimationFrame::duration)
+		.field("data", &WebPAnimationFrame::data)
+		.field("config", &WebPAnimationFrame::config)
+		.field("has_config", &WebPAnimationFrame::has_config);
+
+	emscripten::register_vector<WebPAnimationFrame>("VectorWebPAnimationFrame");
+
 	function("encoder_version", &encoder_version);
 	function("encodeRGB", &encodeRGB);
 	function("encodeRGBA", &encodeRGBA);


### PR DESCRIPTION
## Summary
- Added per-frame configuration support for animated WebP encoding, allowing individual frames to have their own quality and lossless settings
- Introduced `applyPicConfig` helper function to streamline the application of `SimpleWebPConfig` to `WebPConfig`
- Refactored `encode` and `encodeAnimation` functions to use the new helper, improving code readability and maintainability
